### PR TITLE
fix drawer slide out

### DIFF
--- a/src/js/scripts/dashboard.ts
+++ b/src/js/scripts/dashboard.ts
@@ -67,8 +67,8 @@ const openDrawer = () => {
 };
 
 const closeDrawer = () => {
-  popover!.dataset.state = 'close';
-  drawer!.dataset.state = 'close';
+  popover!.dataset.state = 'closed';
+  drawer!.dataset.state = 'closed';
 };
 
 const billsForm = document.querySelector('#bill-form');
@@ -122,8 +122,19 @@ billsForm?.addEventListener('submit', async (e) => {
   }
 });
 
-newBillBtn?.addEventListener('click', openDrawer);
 closeBtn?.addEventListener('click', closeDrawer);
+newBillBtn?.addEventListener('click', openDrawer);
+document.addEventListener('click', (e) => {
+  const target = e.target as HTMLElement;
+  if (
+    target instanceof Node &&
+    !drawer.contains(target) &&
+    !target.matches('#add-new-bill-btn') &&
+    popover.dataset.state === 'open'
+  ) {
+    closeDrawer();
+  }
+});
 
 const SummaryCardsInstance = new SummaryCards();
 SummaryCardsInstance.render();

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -338,13 +338,14 @@
   width: 100%;
   background-color: rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(3px);
-  z-index: -1;
+  z-index: 100;
   opacity: 0;
-  transition: opacity var(--ease-default) var(--duration-normal);
+  transition: opacity var(--duration-normal) var(--ease-default);
   height: 100vh;
+  pointer-events: none;
 }
 
 .backdrop[data-state='open'] {
   opacity: 1;
-  z-index: 100;
+  pointer-events: auto;
 }


### PR DESCRIPTION
- fixed drawer slide out to be smooth, by removing setting the z-index on state="closed"
- fixed pointer events so when the backdrop isn't visible it doesn't get in the way of the main content and when it's open , we can interact with the form.